### PR TITLE
Gemspec requires Trollop ~> 2.0.

### DIFF
--- a/dunmanifestin.gemspec
+++ b/dunmanifestin.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'dunmanifestin'
-  s.version     = '0.0.4'
+  s.version     = '0.0.5'
   s.summary     = 'A verisimilitude generator.'
   s.description = "The point of Dunmanifestin [is] to inject chaos into humans' cliched ideas or, at least, let them be hunter-gatherers instead of farmers of culture. -- B. Christel"
   s.authors     = %w(quavmo benchristel AlexLerman)
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/quavmo/dunmanifestin'
   s.license     = 'MIT'
 
-  s.add_dependency 'trollop', '~> 0'
-  s.add_development_dependency 'rspec', '~> 0'
+  s.add_dependency 'trollop', '~> 2.0'
+  s.add_development_dependency 'rspec', '~> 2.0'
 end


### PR DESCRIPTION
The previous requirement, ~> 0, wasn't letting the dependency resolve on my dev machine, I'm guessing because ~> locks you to the specified major version and I had 2.0 installed.